### PR TITLE
Change UMap to lazy import

### DIFF
--- a/kura/kura.py
+++ b/kura/kura.py
@@ -1,4 +1,3 @@
-from kura.dimensionality import HDBUMAP
 from kura.types import Conversation, Cluster, ClusterTreeNode
 from kura.embedding import OpenAIEmbeddingModel
 from kura.summarisation import SummaryModel
@@ -12,7 +11,7 @@ from kura.base_classes import (
     BaseMetaClusterModel,
     BaseDimensionalityReduction,
 )
-from typing import Union
+from typing import Optional, Union
 import os
 from typing import TypeVar
 from pydantic import BaseModel
@@ -45,7 +44,7 @@ class Kura:
         summarisation_model: BaseSummaryModel = SummaryModel(),
         cluster_model: BaseClusterModel = ClusterModel(),
         meta_cluster_model: BaseMetaClusterModel = MetaClusterModel(),
-        dimensionality_reduction: BaseDimensionalityReduction = HDBUMAP(),
+        dimensionality_reduction: Optional[BaseDimensionalityReduction] = None,
         max_clusters: int = 10,
         checkpoint_dir: str = "./checkpoints",
         conversation_checkpoint_name: str = "conversations.json",
@@ -262,6 +261,11 @@ class Kura:
         )
         if checkpoint_items:
             return checkpoint_items
+
+        if self.dimensionality_reduction is None:
+            from kura.dimensionality import HDBUMAP
+
+            self.dimensionality_reduction = HDBUMAP()
 
         dimensionality_reduced_clusters = (
             await self.dimensionality_reduction.reduce_dimensionality(clusters)


### PR DESCRIPTION
Reduces boot up time by importing uMap lazily
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Lazy import `HDBUMAP` in `kura.py` to reduce boot-up time and update `SummaryModel` defaults in `summarisation.py`.
> 
>   - **Lazy Import**:
>     - `HDBUMAP` is now imported lazily in `reduce_dimensionality()` in `kura.py` to reduce boot-up time.
>     - `dimensionality_reduction` is initialized to `None` in `Kura.__init__()` and set in `reduce_dimensionality()` if not provided.
>   - **SummaryModel Changes**:
>     - Default model changed to `"openai/gpt-4o-mini"` in `SummaryModel.__init__()` in `summarisation.py`.
>     - `semaphore` is initialized in `summarise()` instead of `__init__()` in `summarisation.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=567-labs%2Fkura&utm_source=github&utm_medium=referral)<sup> for 38ad76c639b673b402bdfd68679d7a82e4774f10. You can [customize](https://app.ellipsis.dev/567-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->