### PR TITLE
Feat/add caching summaries

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,7 +106,7 @@ Kura offers two APIs for different use cases:
 
 ### Core Components
 
-1. **Summarisation Model** (`kura/summarisation.py`): Takes user conversations and summarizes them into task descriptions
+1. **Summarisation Model** (`kura/summarisation.py`): Takes user conversations and summarizes them into task descriptions, with optional disk caching using `diskcache`
 2. **Embedding Model** (`kura/embedding.py`): Converts text into vector representations (embeddings)
 3. **Clustering Model** (`kura/cluster.py`): Groups summaries into clusters based on embeddings
 4. **Meta Clustering Model** (`kura/meta_cluster.py`): Further groups clusters into a hierarchical structure (Note: `max_clusters` parameter now lives here, not in the main Kura class)
@@ -125,7 +125,7 @@ Kura offers two APIs for different use cases:
 
 - `Kura` (`kura/kura.py`): Main class that orchestrates the entire pipeline
 - `BaseEmbeddingModel` / `OpenAIEmbeddingModel` (`kura/embedding.py`): Handle text embedding
-- `BaseSummaryModel` / `SummaryModel` (`kura/summarisation.py`): Summarize conversations
+- `BaseSummaryModel` / `SummaryModel` (`kura/summarisation.py`): Summarize conversations with optional disk caching
 - `BaseClusterModel` / `ClusterModel` (`kura/cluster.py`): Create initial clusters
 - `BaseMetaClusterModel` / `MetaClusterModel` (`kura/meta_cluster.py`): Reduce clusters into hierarchical groups
 - `BaseDimensionalityReduction` / `HDBUMAP` (`kura/dimensionality.py`): Reduce dimensions for visualization

--- a/docs/core-concepts/summarization.md
+++ b/docs/core-concepts/summarization.md
@@ -88,6 +88,144 @@ Key features:
 - **Extensibility:** Automatic field mapping from extended schemas to metadata
 - **Concurrency:** Processes multiple conversations in parallel for efficiency
 - **Checkpointing:** Caches results to avoid recomputation
+- **Disk Caching:** Optional persistent caching for individual summaries
+
+---
+
+## Disk Caching
+
+Kura's `SummaryModel` supports optional disk caching using `diskcache` to store individual conversation summaries persistently. This feature significantly reduces API costs and processing time when working with the same conversations repeatedly.
+
+### Benefits
+
+- **Cost Reduction**: Avoid re-summarizing identical conversations across runs
+- **Performance**: Skip expensive LLM calls for cached conversations  
+- **Persistence**: Cache survives between program restarts
+- **Intelligent Keys**: Cache considers all factors that affect output (model, temperature, prompt, etc.)
+
+### Enabling Caching
+
+Caching is **disabled by default**. Enable it by providing a `cache_dir` parameter:
+
+```python
+from kura.summarisation import SummaryModel
+
+# Enable caching with custom directory
+model = SummaryModel(
+    model="openai/gpt-4o-mini",
+    cache_dir="./summary_cache"  # Creates cache directory if needed
+)
+
+# Caching disabled (default behavior)
+model_no_cache = SummaryModel(
+    model="openai/gpt-4o-mini"
+    # cache_dir=None (default)
+)
+```
+
+### How Cache Keys Work
+
+The caching system generates unique keys based on all factors that affect summarization output:
+
+- **Conversation content**: All message roles and content
+- **Model configuration**: The specific model being used  
+- **Generation parameters**: Temperature, prompt text
+- **Schema**: The response schema class name
+- **Additional kwargs**: Any other parameters passed to the summarization
+
+This ensures cached results are only used when the exact same summarization would be generated.
+
+```python
+# These will use different cache entries:
+summaries1 = await model.summarise(conversations, temperature=0.2)
+summaries2 = await model.summarise(conversations, temperature=0.5)  # Different temperature
+
+# These will also use different cache entries:
+summaries3 = await model.summarise(conversations, response_schema=GeneratedSummary)
+summaries4 = await model.summarise(conversations, response_schema=CustomSummary)  # Different schema
+```
+
+### Usage Examples
+
+**Basic caching setup:**
+
+```python
+from kura import summarise_conversations
+from kura.summarisation import SummaryModel
+
+async def main():
+    # Initialize model with caching enabled
+    model = SummaryModel(
+        model="openai/gpt-4o-mini",
+        cache_dir="./my_summary_cache"
+    )
+    
+    # First run: generates summaries and caches them
+    summaries = await summarise_conversations(conversations, model=model)
+    print(f"Generated {len(summaries)} summaries")
+    
+    # Second run: loads from cache (much faster!)
+    summaries_cached = await summarise_conversations(conversations, model=model)
+    print(f"Loaded {len(summaries_cached)} summaries from cache")
+```
+
+**Working with different cache directories:**
+
+```python
+# Separate caches for different model configurations
+gpt4_model = SummaryModel(
+    model="openai/gpt-4o", 
+    cache_dir="./cache/gpt4"
+)
+
+claude_model = SummaryModel(
+    model="anthropic/claude-3-5-sonnet-20241022",
+    cache_dir="./cache/claude"
+)
+
+# Each model maintains its own cache
+gpt4_summaries = await summarise_conversations(conversations, model=gpt4_model)
+claude_summaries = await summarise_conversations(conversations, model=claude_model)
+```
+
+**Cache behavior with custom prompts:**
+
+```python
+model = SummaryModel(cache_dir="./cache")
+
+# Different prompts create separate cache entries
+summaries_default = await model.summarise(
+    conversations
+    # Uses default CLIO prompt
+)
+
+summaries_custom = await model.summarise(
+    conversations,
+    prompt="Focus specifically on technical complexity and user satisfaction."
+)
+
+# Each prompt variation gets its own cached results
+```
+
+### Cache Management
+
+The cache is managed automatically, but you can control the cache directory location:
+
+```python
+import os
+from kura.summarisation import SummaryModel
+
+# Use environment variable for cache location
+cache_dir = os.getenv("KURA_CACHE_DIR", "./default_cache")
+model = SummaryModel(cache_dir=cache_dir)
+
+# Or use project-specific cache directories
+model = SummaryModel(cache_dir=f"./cache/{project_name}/summaries")
+```
+
+**Cache size considerations:** The cache grows with unique conversations. Each cached summary includes the full `ConversationSummary` object. Monitor cache directory size for large-scale deployments.
+
+**Cache invalidation:** The cache automatically handles invalidation through intelligent key generation. No manual cache clearing is needed unless you want to force regeneration of all summaries.
 
 ---
 

--- a/kura/summarisation.py
+++ b/kura/summarisation.py
@@ -150,7 +150,8 @@ class SummaryModel(BaseSummaryModel):
             tuple(message_data),
             response_schema.__name__,
             hashlib.md5(prompt.encode()).hexdigest(),
-            temperature
+            temperature,
+            self.model
         )
         
         return hashlib.md5(str(cache_components).encode()).hexdigest()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
     "sqlmodel>=0.0.14",
     "datasets>=3.6.0",
     "pyarrow>=10.0.0",
+    "diskcache>=5.6.3",
 ]
 
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add caching for conversation summaries using `diskcache` in `SummaryModel` and update dependencies in `pyproject.toml`.
> 
>   - **Caching**:
>     - Add `diskcache` for caching conversation summaries in `SummaryModel` in `summarisation.py`.
>     - Initialize cache in `__init__()` and use `_get_cache_key()` to generate cache keys.
>     - Check cache in `_summarise_single_conversation()` before generating summaries.
>     - Cache new summaries after generation.
>   - **Dependencies**:
>     - Add `diskcache>=5.6.3` to `pyproject.toml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=567-labs%2Fkura&utm_source=github&utm_medium=referral)<sup> for ca58a0d9a287da7cac65cb4c6fa1277d8deab435. You can [customize](https://app.ellipsis.dev/567-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->