### PR TITLE
feat: add caching mechanism for cluster description generation

### DIFF
--- a/kura/base_classes/cluster.py
+++ b/kura/base_classes/cluster.py
@@ -1,7 +1,8 @@
 from abc import ABC, abstractmethod
 from kura.types.summarisation import ConversationSummary
 from kura.types.cluster import Cluster
-from typing import Dict, List
+from typing import Dict, List, Optional
+import hashlib
 
 
 class BaseClusterDescriptionModel(ABC):
@@ -18,4 +19,55 @@ class BaseClusterDescriptionModel(ABC):
         prompt: str,
         max_contrastive_examples: int = 10,
     ) -> List[Cluster]:
+        """Generate cluster descriptions for all clusters."""
         pass
+
+    @abstractmethod
+    async def generate_cluster_description(
+        self,
+        summaries: List[ConversationSummary],
+        contrastive_examples: List[ConversationSummary],
+        prompt: str,
+        cache_dir: Optional[str] = None,
+        **kwargs
+    ) -> "Cluster":
+        """
+        Generate a single cluster description with optional caching.
+        
+        Args:
+            summaries: Summaries in this cluster  
+            contrastive_examples: Examples from other clusters for contrast
+            prompt: Prompt template for cluster generation
+            cache_dir: Optional directory for disk caching
+            **kwargs: Additional model parameters
+            
+        Returns:
+            Generated cluster with name and description
+        """
+        pass
+    
+    def _get_cluster_cache_key(
+        self,
+        summaries: List[ConversationSummary],
+        contrastive_examples: List[ConversationSummary],
+        prompt: str,
+        **kwargs
+    ) -> str:
+        """Generate cache key for a single cluster description."""
+        # Hash cluster summaries (sorted for stability)
+        cluster_reprs = [str(summary) for summary in summaries]
+        cluster_hash = hashlib.md5(''.join(sorted(cluster_reprs)).encode()).hexdigest()
+        
+        # Hash contrastive examples (sorted for stability)
+        contrastive_reprs = [str(summary) for summary in contrastive_examples]
+        contrastive_hash = hashlib.md5(''.join(sorted(contrastive_reprs)).encode()).hexdigest()
+        
+        # Final cache key
+        cache_components = (
+            cluster_hash,
+            contrastive_hash, 
+            hashlib.md5(prompt.encode()).hexdigest(),
+            self.checkpoint_filename,
+        )
+        
+        return hashlib.md5(str(cache_components).encode()).hexdigest()

--- a/kura/base_classes/cluster.py
+++ b/kura/base_classes/cluster.py
@@ -28,7 +28,6 @@ class BaseClusterDescriptionModel(ABC):
         summaries: List[ConversationSummary],
         contrastive_examples: List[ConversationSummary],
         prompt: str,
-        cache_dir: Optional[str] = None,
         **kwargs
     ) -> "Cluster":
         """
@@ -38,7 +37,6 @@ class BaseClusterDescriptionModel(ABC):
             summaries: Summaries in this cluster  
             contrastive_examples: Examples from other clusters for contrast
             prompt: Prompt template for cluster generation
-            cache_dir: Optional directory for disk caching
             **kwargs: Additional model parameters
             
         Returns:


### PR DESCRIPTION
Adding caching mechanism for cluster description
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds optional caching for cluster description generation using `diskcache`, improving efficiency by avoiding redundant computations.
> 
>   - **Caching Mechanism**:
>     - Adds optional caching to `generate_cluster_description()` in `BaseClusterDescriptionModel` and `ClusterDescriptionModel`.
>     - Uses `diskcache` for caching if `cache_dir` is provided.
>     - Cache key generated using summaries, contrastive examples, and prompt.
>   - **Functions**:
>     - Implements `_get_cluster_cache_key()` in both `BaseClusterDescriptionModel` and `ClusterDescriptionModel` to create unique cache keys.
>     - Checks cache before generating cluster descriptions and caches results after generation.
>   - **Initialization**:
>     - Adds `cache_dir` parameter to `ClusterDescriptionModel` constructor to specify cache directory.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=567-labs%2Fkura&utm_source=github&utm_medium=referral)<sup> for 204f6fee388bd8c7ac15dc9209c8f1babcfe1086. You can [customize](https://app.ellipsis.dev/567-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->