### PR TITLE
feat: add import benchmark workflow

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -26,6 +26,8 @@ jobs:
       run: uv sync
     
     - name: Run import benchmark
+      env:
+        OPENAI_API_KEY: sk-mock-key-for-testing
       run: |
         uv run python -c "
         import time
@@ -60,3 +62,4 @@ jobs:
         print(f'Total import time: {total_time:.4f}s')
         print('========================')
         "
+        

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,62 @@
+name: Import Benchmark
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  workflow_dispatch:
+
+jobs:
+  benchmark:
+    runs-on: ubuntu-latest
+    
+    steps:
+    - uses: actions/checkout@v4
+    
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.11'
+    
+    - name: Install uv
+      uses: astral-sh/setup-uv@v3
+    
+    - name: Install dependencies
+      run: uv sync
+    
+    - name: Run import benchmark
+      run: |
+        uv run python -c "
+        import time
+        import sys
+        
+        print('=== Kura Import Benchmark ===')
+        print(f'Python version: {sys.version}')
+        print()
+        
+        # Benchmark kura.types import
+        start_time = time.perf_counter()
+        try:
+            import kura.types
+            types_time = time.perf_counter() - start_time
+            print(f'✓ kura.types import: {types_time:.4f}s')
+        except Exception as e:
+            print(f'✗ kura.types import failed: {e}')
+            types_time = 0
+        
+        # Benchmark kura import
+        start_time = time.perf_counter()
+        try:
+            import kura
+            kura_time = time.perf_counter() - start_time
+            print(f'✓ kura import: {kura_time:.4f}s')
+        except Exception as e:
+            print(f'✗ kura import failed: {e}')
+            kura_time = 0
+        
+        total_time = types_time + kura_time
+        print()
+        print(f'Total import time: {total_time:.4f}s')
+        print('========================')
+        "

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -28,38 +28,5 @@ jobs:
     - name: Run import benchmark
       env:
         OPENAI_API_KEY: sk-mock-key-for-testing
-      run: |
-        uv run python -c "
-        import time
-        import sys
-        
-        print('=== Kura Import Benchmark ===')
-        print(f'Python version: {sys.version}')
-        print()
-        
-        # Benchmark kura.types import
-        start_time = time.perf_counter()
-        try:
-            import kura.types
-            types_time = time.perf_counter() - start_time
-            print(f'✓ kura.types import: {types_time:.4f}s')
-        except Exception as e:
-            print(f'✗ kura.types import failed: {e}')
-            types_time = 0
-        
-        # Benchmark kura import
-        start_time = time.perf_counter()
-        try:
-            import kura
-            kura_time = time.perf_counter() - start_time
-            print(f'✓ kura import: {kura_time:.4f}s')
-        except Exception as e:
-            print(f'✗ kura import failed: {e}')
-            kura_time = 0
-        
-        total_time = types_time + kura_time
-        print()
-        print(f'Total import time: {total_time:.4f}s')
-        print('========================')
-        "
-        
+      run: uv run python benchmark.py
+

--- a/benchmark.py
+++ b/benchmark.py
@@ -1,16 +1,49 @@
 #!/usr/bin/env python3
 """Import performance benchmark for Kura."""
 
-import time
+import subprocess
 import sys
 
 
+def test_import_time(module_name):
+    """Test import time for a module in isolation using subprocess."""
+    code = f"""
+import time
+start = time.perf_counter()
+try:
+    import {module_name}
+    print(time.perf_counter() - start)
+except Exception as e:
+    print(f"ERROR: {{e}}")
+"""
+    
+    try:
+        result = subprocess.run(
+            [sys.executable, "-c", code],
+            capture_output=True,
+            text=True,
+            timeout=30
+        )
+        
+        if result.returncode == 0:
+            output = result.stdout.strip()
+            if output.startswith("ERROR"):
+                return None, output
+            return float(output), None
+        else:
+            return None, f"Failed with code {result.returncode}: {result.stderr}"
+    except subprocess.TimeoutExpired:
+        return None, "Timeout (>30s)"
+    except Exception as e:
+        return None, f"Subprocess error: {e}"
+
+
 def main():
-    print('=== Kura Import Benchmark ===')
+    print('=== Kura Import Benchmark (Isolated) ===')
     print(f'Python version: {sys.version}')
     print()
     
-    # Benchmark individual module imports
+    # Benchmark individual module imports in isolation
     modules_to_test = [
         'kura.types',
         'kura.k_means',
@@ -23,14 +56,12 @@ def main():
     total_time = 0
     
     for module in modules_to_test:
-        start_time = time.perf_counter()
-        try:
-            __import__(module)
-            import_time = time.perf_counter() - start_time
+        import_time, error = test_import_time(module)
+        if import_time is not None:
             total_time += import_time
             print(f'{module}: {import_time:.4f}s')
-        except Exception as e:
-            print(f'{module}: failed - {e}')
+        else:
+            print(f'{module}: failed - {error}')
     
     print()
     print(f'Total import time: {total_time:.4f}s')

--- a/benchmark.py
+++ b/benchmark.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+"""Import performance benchmark for Kura."""
+
+import time
+import sys
+
+
+def main():
+    print('=== Kura Import Benchmark ===')
+    print(f'Python version: {sys.version}')
+    print()
+    
+    # Benchmark individual module imports
+    modules_to_test = [
+        'kura.types',
+        'kura.k_means',
+        'kura.hdbscan', 
+        'kura.embedding',
+        'kura.summarisation',
+        'kura'
+    ]
+    
+    total_time = 0
+    
+    for module in modules_to_test:
+        start_time = time.perf_counter()
+        try:
+            __import__(module)
+            import_time = time.perf_counter() - start_time
+            total_time += import_time
+            print(f'{module}: {import_time:.4f}s')
+        except Exception as e:
+            print(f'{module}: failed - {e}')
+    
+    print()
+    print(f'Total import time: {total_time:.4f}s')
+    print('========================')
+
+
+if __name__ == '__main__':
+    main()

--- a/benchmark.py
+++ b/benchmark.py
@@ -3,6 +3,9 @@
 
 import subprocess
 import sys
+import statistics
+import concurrent.futures
+from typing import List, Tuple, Optional
 
 
 def test_import_time(module_name):
@@ -38,8 +41,34 @@ except Exception as e:
         return None, f"Subprocess error: {e}"
 
 
+def test_import_multiple_times(module_name: str, num_runs: int = 5) -> Tuple[Optional[List[float]], Optional[str]]:
+    """Test import time for a module multiple times in parallel."""
+    with concurrent.futures.ThreadPoolExecutor(max_workers=num_runs) as executor:
+        # Submit all tasks
+        futures = [executor.submit(test_import_time, module_name) for _ in range(num_runs)]
+        
+        times = []
+        errors = []
+        
+        # Collect results
+        for future in concurrent.futures.as_completed(futures):
+            import_time, error = future.result()
+            if import_time is not None:
+                times.append(import_time)
+            else:
+                errors.append(error)
+        
+        if not times:
+            return None, f"All runs failed: {errors}"
+        
+        if errors:
+            print(f"  Warning: {len(errors)} out of {num_runs} runs failed")
+        
+        return times, None
+
+
 def main():
-    print('=== Kura Import Benchmark (Isolated) ===')
+    print('=== Kura Import Benchmark (5 runs per module) ===')
     print(f'Python version: {sys.version}')
     print()
     
@@ -53,18 +82,40 @@ def main():
         'kura'
     ]
     
-    total_time = 0
+    total_mean_time = 0
+    results = {}
     
     for module in modules_to_test:
-        import_time, error = test_import_time(module)
-        if import_time is not None:
-            total_time += import_time
-            print(f'{module}: {import_time:.4f}s')
+        print(f'Testing {module}...')
+        times, error = test_import_multiple_times(module, num_runs=5)
+        
+        if times is not None:
+            mean_time = statistics.mean(times)
+            std_time = statistics.stdev(times) if len(times) > 1 else 0
+            min_time = min(times)
+            max_time = max(times)
+            
+            total_mean_time += mean_time
+            results[module] = {
+                'mean': mean_time,
+                'std': std_time,
+                'min': min_time,
+                'max': max_time,
+                'times': times
+            }
+            
+            print(f'{module}: {mean_time:.4f}s ± {std_time:.4f}s (min: {min_time:.4f}s, max: {max_time:.4f}s)')
+            print(f'  Individual times: {[f"{t:.4f}s" for t in times]}')
         else:
             print(f'{module}: failed - {error}')
     
     print()
-    print(f'Total import time: {total_time:.4f}s')
+    print('=== Summary ===')
+    for module, stats in results.items():
+        print(f'{module}: {stats["mean"]:.4f}s ± {stats["std"]:.4f}s')
+    
+    print()
+    print(f'Total mean import time: {total_mean_time:.4f}s')
     print('========================')
 
 

--- a/kura/__init__.py
+++ b/kura/__init__.py
@@ -1,3 +1,40 @@
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    # Import types for static analysis
+    from .checkpoint import CheckpointManager
+    from .checkpoints import MultiCheckpointManager
+    from .summarisation import SummaryModel, summarise_conversations
+    from .cluster import (
+        ClusterDescriptionModel,
+        generate_base_clusters_from_conversation_summaries,
+    )
+    from .v1.kura import (
+        reduce_clusters_from_base_clusters,
+        reduce_dimensionality_from_clusters,
+    )
+    from .meta_cluster import MetaClusterModel
+    from .types import Conversation
+    from .k_means import KmeansClusteringMethod, MiniBatchKmeansClusteringMethod
+    from .hdbscan import HDBSCANClusteringMethod
+    from .v1.visualization import (
+        visualise_pipeline_results,
+        visualise_clusters_rich,
+        visualise_clusters_enhanced,
+        visualise_clusters,
+    )
+    
+    # Optional imports for type checking
+    try:
+        from .checkpoints.parquet import ParquetCheckpointManager
+    except ImportError:
+        ParquetCheckpointManager = None
+    
+    try:
+        from .checkpoints.hf_dataset import HFDatasetCheckpointManager
+    except ImportError:
+        HFDatasetCheckpointManager = None
+
 # Lazy loading configuration
 _LAZY_IMPORTS = {
     # Core models

--- a/kura/__init__.py
+++ b/kura/__init__.py
@@ -1,25 +1,5 @@
-from .checkpoint import CheckpointManager
-from .checkpoints import MultiCheckpointManager
-from .summarisation import SummaryModel, summarise_conversations
-from .cluster import (
-    ClusterDescriptionModel,
-    generate_base_clusters_from_conversation_summaries,
-)
-from .v1.kura import (
-    reduce_clusters_from_base_clusters,
-    reduce_dimensionality_from_clusters,
-)
-from .meta_cluster import MetaClusterModel
-
+# Light imports - these are fast to load
 from .types import Conversation
-from .k_means import KmeansClusteringMethod, MiniBatchKmeansClusteringMethod
-from .hdbscan import HDBSCANClusteringMethod
-from .v1.visualization import (
-    visualise_pipeline_results,
-    visualise_clusters_rich,
-    visualise_clusters_enhanced,
-    visualise_clusters,
-)
 
 # Import ParquetCheckpointManager from checkpoints module if available
 try:
@@ -37,6 +17,73 @@ try:
 except ImportError:
     HFDatasetCheckpointManager = None
     HF_AVAILABLE = False
+
+
+def __getattr__(name: str):
+    """Lazy loading for heavy imports to improve startup time."""
+    # Checkpoint managers
+    if name == "CheckpointManager":
+        from .checkpoint import CheckpointManager
+        return CheckpointManager
+    elif name == "MultiCheckpointManager":
+        from .checkpoints import MultiCheckpointManager
+        return MultiCheckpointManager
+    
+    # Summary models and functions
+    elif name == "SummaryModel":
+        from .summarisation import SummaryModel
+        return SummaryModel
+    elif name == "summarise_conversations":
+        from .summarisation import summarise_conversations
+        return summarise_conversations
+    
+    # Clustering models and functions
+    elif name == "ClusterDescriptionModel":
+        from .cluster import ClusterDescriptionModel
+        return ClusterDescriptionModel
+    elif name == "generate_base_clusters_from_conversation_summaries":
+        from .cluster import generate_base_clusters_from_conversation_summaries
+        return generate_base_clusters_from_conversation_summaries
+    
+    # Clustering methods
+    elif name == "KmeansClusteringMethod":
+        from .k_means import KmeansClusteringMethod
+        return KmeansClusteringMethod
+    elif name == "MiniBatchKmeansClusteringMethod":
+        from .k_means import MiniBatchKmeansClusteringMethod
+        return MiniBatchKmeansClusteringMethod
+    elif name == "HDBSCANClusteringMethod":
+        from .hdbscan import HDBSCANClusteringMethod
+        return HDBSCANClusteringMethod
+    
+    # Meta clustering
+    elif name == "MetaClusterModel":
+        from .meta_cluster import MetaClusterModel
+        return MetaClusterModel
+    
+    # V1 functions
+    elif name == "reduce_clusters_from_base_clusters":
+        from .v1.kura import reduce_clusters_from_base_clusters
+        return reduce_clusters_from_base_clusters
+    elif name == "reduce_dimensionality_from_clusters":
+        from .v1.kura import reduce_dimensionality_from_clusters
+        return reduce_dimensionality_from_clusters
+    
+    # Visualization functions
+    elif name == "visualise_pipeline_results":
+        from .v1.visualization import visualise_pipeline_results
+        return visualise_pipeline_results
+    elif name == "visualise_clusters_rich":
+        from .v1.visualization import visualise_clusters_rich
+        return visualise_clusters_rich
+    elif name == "visualise_clusters_enhanced":
+        from .v1.visualization import visualise_clusters_enhanced
+        return visualise_clusters_enhanced
+    elif name == "visualise_clusters":
+        from .v1.visualization import visualise_clusters
+        return visualise_clusters
+    
+    raise AttributeError(f"module '{__name__}' has no attribute '{name}'")
 
 
 __all__ = [

--- a/kura/__init__.py
+++ b/kura/__init__.py
@@ -2,34 +2,34 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     # Import types for static analysis
-    from .checkpoint import CheckpointManager
-    from .checkpoints import MultiCheckpointManager
-    from .summarisation import SummaryModel, summarise_conversations
+    from .checkpoint import CheckpointManager  # noqa: F401
+    from .checkpoints import MultiCheckpointManager  # noqa: F401
+    from .summarisation import SummaryModel, summarise_conversations  # noqa: F401
     from .cluster import (
-        ClusterDescriptionModel,
-        generate_base_clusters_from_conversation_summaries,
+        ClusterDescriptionModel,  # noqa: F401
+        generate_base_clusters_from_conversation_summaries,  # noqa: F401
     )
     from .v1.kura import (
-        reduce_clusters_from_base_clusters,
-        reduce_dimensionality_from_clusters,
+        reduce_clusters_from_base_clusters,  # noqa: F401
+        reduce_dimensionality_from_clusters,  # noqa: F401
     )
-    from .meta_cluster import MetaClusterModel
-    from .types import Conversation
-    from .k_means import KmeansClusteringMethod, MiniBatchKmeansClusteringMethod
-    from .hdbscan import HDBSCANClusteringMethod
+    from .meta_cluster import MetaClusterModel  # noqa: F401
+    from .types import Conversation  # noqa: F401
+    from .k_means import KmeansClusteringMethod, MiniBatchKmeansClusteringMethod  # noqa: F401
+    from .hdbscan import HDBSCANClusteringMethod  # noqa: F401
     from .v1.visualization import (
-        visualise_pipeline_results,
-        visualise_clusters_rich,
-        visualise_clusters_enhanced,
-        visualise_clusters,
+        visualise_pipeline_results,  # noqa: F401
+        visualise_clusters_rich,  # noqa: F401
+        visualise_clusters_enhanced,  # noqa: F401
+        visualise_clusters,  # noqa: F401
     )
-    
+
     # Optional imports for type checking
     try:
         from .checkpoints.parquet import ParquetCheckpointManager
     except ImportError:
         ParquetCheckpointManager = None
-    
+
     try:
         from .checkpoints.hf_dataset import HFDatasetCheckpointManager
     except ImportError:
@@ -41,69 +41,94 @@ _LAZY_IMPORTS = {
     "SummaryModel": ("kura.summarisation", "SummaryModel"),
     "ClusterDescriptionModel": ("kura.cluster", "ClusterDescriptionModel"),
     "MetaClusterModel": ("kura.meta_cluster", "MetaClusterModel"),
-    
     # Types
     "Conversation": ("kura.types", "Conversation"),
-    
     # Checkpoint managers
     "CheckpointManager": ("kura.checkpoint", "CheckpointManager"),
     "MultiCheckpointManager": ("kura.checkpoints", "MultiCheckpointManager"),
-    
     # Clustering methods
     "KmeansClusteringMethod": ("kura.k_means", "KmeansClusteringMethod"),
-    "MiniBatchKmeansClusteringMethod": ("kura.k_means", "MiniBatchKmeansClusteringMethod"),
+    "MiniBatchKmeansClusteringMethod": (
+        "kura.k_means",
+        "MiniBatchKmeansClusteringMethod",
+    ),
     "HDBSCANClusteringMethod": ("kura.hdbscan", "HDBSCANClusteringMethod"),
-    
     # Procedural functions
     "summarise_conversations": ("kura.summarisation", "summarise_conversations"),
-    "generate_base_clusters_from_conversation_summaries": ("kura.cluster", "generate_base_clusters_from_conversation_summaries"),
-    "reduce_clusters_from_base_clusters": ("kura.v1.kura", "reduce_clusters_from_base_clusters"),
-    "reduce_dimensionality_from_clusters": ("kura.v1.kura", "reduce_dimensionality_from_clusters"),
-    
+    "generate_base_clusters_from_conversation_summaries": (
+        "kura.cluster",
+        "generate_base_clusters_from_conversation_summaries",
+    ),
+    "reduce_clusters_from_base_clusters": (
+        "kura.v1.kura",
+        "reduce_clusters_from_base_clusters",
+    ),
+    "reduce_dimensionality_from_clusters": (
+        "kura.v1.kura",
+        "reduce_dimensionality_from_clusters",
+    ),
     # Visualization
-    "visualise_pipeline_results": ("kura.v1.visualization", "visualise_pipeline_results"),
+    "visualise_pipeline_results": (
+        "kura.v1.visualization",
+        "visualise_pipeline_results",
+    ),
     "visualise_clusters_rich": ("kura.v1.visualization", "visualise_clusters_rich"),
-    "visualise_clusters_enhanced": ("kura.v1.visualization", "visualise_clusters_enhanced"),
+    "visualise_clusters_enhanced": (
+        "kura.v1.visualization",
+        "visualise_clusters_enhanced",
+    ),
     "visualise_clusters": ("kura.v1.visualization", "visualise_clusters"),
 }
 
 # Optional imports that may not be available
 _OPTIONAL_IMPORTS = {
-    "ParquetCheckpointManager": ("kura.checkpoints.parquet", "ParquetCheckpointManager"),
-    "HFDatasetCheckpointManager": ("kura.checkpoints.hf_dataset", "HFDatasetCheckpointManager"),
+    "ParquetCheckpointManager": (
+        "kura.checkpoints.parquet",
+        "ParquetCheckpointManager",
+    ),
+    "HFDatasetCheckpointManager": (
+        "kura.checkpoints.hf_dataset",
+        "HFDatasetCheckpointManager",
+    ),
 }
+
 
 def __getattr__(name: str):
     """Lazy loading of modules using __getattr__."""
     # Check if already cached
     if name in globals():
         return globals()[name]
-    
+
     # Check required imports
     if name in _LAZY_IMPORTS:
         module_path, attr_name = _LAZY_IMPORTS[name]
         try:
             from importlib import import_module
+
             module = import_module(module_path)
             attr = getattr(module, attr_name)
             globals()[name] = attr  # Cache it
             return attr
         except ImportError as e:
             raise ImportError(f"Failed to import {name} from {module_path}: {e}")
-    
+
     # Check optional imports
     if name in _OPTIONAL_IMPORTS:
         module_path, attr_name = _OPTIONAL_IMPORTS[name]
         try:
             from importlib import import_module
+
             module = import_module(module_path)
             attr = getattr(module, attr_name)
             globals()[name] = attr  # Cache it
             return attr
         except ImportError:
-            raise ImportError(f"Optional dependency {name} is not available. Install the required packages.")
-    
+            raise ImportError(
+                f"Optional dependency {name} is not available. Install the required packages."
+            )
+
     raise AttributeError(f"module 'kura' has no attribute '{name}'")
+
 
 __all__ = list(_LAZY_IMPORTS.keys()) + list(_OPTIONAL_IMPORTS.keys())
 

--- a/kura/base_classes/cluster.py
+++ b/kura/base_classes/cluster.py
@@ -1,7 +1,9 @@
 from abc import ABC, abstractmethod
-from kura.types.summarisation import ConversationSummary
-from kura.types.cluster import Cluster
-from typing import Dict, List
+from typing import Dict, List, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from kura.types.summarisation import ConversationSummary
+    from kura.types.cluster import Cluster
 
 
 class BaseClusterDescriptionModel(ABC):
@@ -14,8 +16,8 @@ class BaseClusterDescriptionModel(ABC):
     @abstractmethod
     async def generate_clusters(
         self,
-        cluster_id_to_summaries: Dict[int, List[ConversationSummary]],
+        cluster_id_to_summaries: Dict[int, List["ConversationSummary"]],
         prompt: str,
         max_contrastive_examples: int = 10,
-    ) -> List[Cluster]:
+    ) -> List["Cluster"]:
         pass

--- a/kura/base_classes/clustering_method.py
+++ b/kura/base_classes/clustering_method.py
@@ -1,12 +1,14 @@
 from abc import ABC, abstractmethod
-from kura.types.summarisation import ConversationSummary
-from typing import Union
+from typing import Union, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from kura.types.summarisation import ConversationSummary
 
 
 class BaseClusteringMethod(ABC):
     @abstractmethod
     def cluster(
-        self, items: list[dict[str, Union[ConversationSummary, list[float]]]]
-    ) -> dict[int, list[ConversationSummary]]:
+        self, items: list[dict[str, Union["ConversationSummary", list[float]]]]
+    ) -> dict[int, list["ConversationSummary"]]:
         """Clustering method takes in a item + embedding and returns a mapping of cluster ids to items"""
         pass

--- a/kura/base_classes/dimensionality.py
+++ b/kura/base_classes/dimensionality.py
@@ -1,6 +1,8 @@
 from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING
 
-from kura.types import Cluster, ProjectedCluster
+if TYPE_CHECKING:
+    from kura.types import Cluster, ProjectedCluster
 
 
 class BaseDimensionalityReduction(ABC):
@@ -12,8 +14,8 @@ class BaseDimensionalityReduction(ABC):
 
     @abstractmethod
     async def reduce_dimensionality(
-        self, clusters: list[Cluster]
-    ) -> list[ProjectedCluster]:
+        self, clusters: list["Cluster"]
+    ) -> list["ProjectedCluster"]:
         """
         This reduces the dimensionality of the individual clusters that we've created so we can visualise them in a lower dimension
         """

--- a/kura/base_classes/meta_cluster.py
+++ b/kura/base_classes/meta_cluster.py
@@ -1,5 +1,8 @@
 from abc import ABC, abstractmethod
-from kura.types.cluster import Cluster
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from kura.types.cluster import Cluster
 
 
 class BaseMetaClusterModel(ABC):
@@ -10,5 +13,5 @@ class BaseMetaClusterModel(ABC):
         pass
 
     @abstractmethod
-    async def reduce_clusters(self, clusters: list[Cluster]) -> list[Cluster]:
+    async def reduce_clusters(self, clusters: list["Cluster"]) -> list["Cluster"]:
         pass

--- a/kura/base_classes/summarisation.py
+++ b/kura/base_classes/summarisation.py
@@ -1,10 +1,11 @@
 from abc import ABC, abstractmethod
-from typing import Type, TypeVar
+from typing import Type, TypeVar, TYPE_CHECKING
 
-from kura.types import Conversation, GeneratedSummary, ConversationSummary
+if TYPE_CHECKING:
+    from kura.types import Conversation, GeneratedSummary, ConversationSummary
 
 
-T = TypeVar("T", bound=GeneratedSummary)
+T = TypeVar("T", bound="GeneratedSummary")
 
 
 class BaseSummaryModel(ABC):
@@ -24,14 +25,14 @@ class BaseSummaryModel(ABC):
     @abstractmethod
     async def summarise(
         self,
-        conversations: list[Conversation],
+        conversations: list["Conversation"],
         prompt: str,
         *,
         # All configuration exposed as parameters (not buried in class)
-        response_schema: Type[T] = GeneratedSummary,
+        response_schema: Type[T] = "GeneratedSummary",
         temperature: float = 0.2,
         **kwargs,
-    ) -> list[ConversationSummary]:
+    ) -> list["ConversationSummary"]:
         """
         Summarise conversations with configurable parameters.
 

--- a/kura/cluster.py
+++ b/kura/cluster.py
@@ -438,9 +438,9 @@ def get_contrastive_examples(
 
 async def generate_base_clusters_from_conversation_summaries(
     summaries: List[ConversationSummary],
-    embedding_model: BaseEmbeddingModel = OpenAIEmbeddingModel(),
-    clustering_method: BaseClusteringMethod = KmeansClusteringModel(),
-    clustering_model: BaseClusterDescriptionModel = ClusterDescriptionModel(),
+    embedding_model: Optional[BaseEmbeddingModel] = None,
+    clustering_method: Optional[BaseClusteringMethod] = None,
+    clustering_model: Optional[BaseClusterDescriptionModel] = None,
     checkpoint_manager: Optional[CheckpointManager] = None,
     max_contrastive_examples: int = 10,
     prompt: str = DEFAULT_CLUSTER_PROMPT,
@@ -464,6 +464,14 @@ async def generate_base_clusters_from_conversation_summaries(
     """
     if not summaries:
         raise ValueError("Empty summaries list provided")
+
+    # Lazy instantiation of default models
+    if embedding_model is None:
+        embedding_model = OpenAIEmbeddingModel()
+    if clustering_method is None:
+        clustering_method = KmeansClusteringModel()
+    if clustering_model is None:
+        clustering_model = ClusterDescriptionModel()
 
     if checkpoint_manager:
         cached = checkpoint_manager.load_checkpoint(

--- a/kura/cluster.py
+++ b/kura/cluster.py
@@ -10,7 +10,6 @@ from kura.types.cluster import Cluster, GeneratedCluster
 import logging
 import math
 from typing import Union, cast, Dict, List, Optional
-import numpy as np
 import asyncio
 import instructor
 from instructor.models import KnownModelName
@@ -356,6 +355,7 @@ class KmeansClusteringModel(BaseClusteringMethod):
                 f"Calculated {n_clusters} clusters for {len(data)} items (target: {self.clusters_per_group} items per cluster)"
             )
 
+            import numpy as np
             X = np.array(embeddings)
             logger.debug(f"Created embedding matrix of shape {X.shape}")
 
@@ -426,6 +426,7 @@ def get_contrastive_examples(
         return all_examples
 
     # Otherwise sample without replacement
+    import numpy as np
     selected = list(
         np.random.choice(all_examples, size=max_contrastive_examples, replace=False)
     )

--- a/kura/dimensionality.py
+++ b/kura/dimensionality.py
@@ -3,7 +3,6 @@ from kura.types import Cluster, ProjectedCluster
 from kura.embedding import OpenAIEmbeddingModel
 from kura.utils import calculate_cluster_levels
 from typing import Union
-import numpy as np
 import logging
 
 logger = logging.getLogger(__name__)
@@ -58,6 +57,7 @@ class HDBUMAP(BaseDimensionalityReduction):
             )
             return []
 
+        import numpy as np
         embeddings = np.array(cluster_embeddings)
         logger.debug(f"Created embedding matrix of shape {embeddings.shape}")
 

--- a/kura/hdbscan.py
+++ b/kura/hdbscan.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
 from kura.base_classes import BaseClusteringMethod
-import hdbscan
 from typing import TypeVar
-import numpy as np
 import logging
 
 logger = logging.getLogger(__name__)
@@ -79,6 +77,8 @@ class HDBSCANClusteringMethod(BaseClusteringMethod):
 
             logger.debug(f"Extracted embeddings for {len(data)} items")
 
+            import numpy as np
+            import hdbscan
             X = np.array(embeddings)
             logger.debug(f"Created embedding matrix of shape {X.shape}")
 

--- a/kura/k_means.py
+++ b/kura/k_means.py
@@ -1,8 +1,6 @@
 from kura.base_classes import BaseClusteringMethod
-from sklearn.cluster import KMeans, MiniBatchKMeans
 import math
 from typing import TypeVar
-import numpy as np
 import logging
 
 logger = logging.getLogger(__name__)
@@ -46,6 +44,8 @@ class KmeansClusteringMethod(BaseClusteringMethod):
                 f"Calculated {n_clusters} clusters for {len(data)} items (target: {self.clusters_per_group} items per cluster)"
             )
 
+            import numpy as np
+            from sklearn.cluster import KMeans
             X = np.array(embeddings)
             logger.debug(f"Created embedding matrix of shape {X.shape}")
 
@@ -154,6 +154,8 @@ class MiniBatchKmeansClusteringMethod(BaseClusteringMethod):
                 f"(target: {self.clusters_per_group} items per cluster)"
             )
 
+            import numpy as np
+            from sklearn.cluster import MiniBatchKMeans
             X = np.array(embeddings)
             logger.debug(f"Created embedding matrix of shape {X.shape}")
 

--- a/kura/types/conversation.py
+++ b/kura/types/conversation.py
@@ -3,7 +3,6 @@ from datetime import datetime
 from typing import Literal, Union, Callable
 import json
 import importlib
-from tqdm import tqdm
 
 metadata_dict = dict[
     str, Union[str, int, float, bool, list[str], list[int], list[float]]
@@ -64,6 +63,8 @@ class Conversation(BaseModel):
         else:
             dataset = load_dataset(dataset_name, split=split, streaming=True)
 
+        from tqdm import tqdm
+        
         return [
             Conversation(
                 chat_id=chat_id_fn(item),


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adds import benchmark workflow and refactors Kura for lazy imports and type checking.
> 
>   - **Workflow**:
>     - Adds `benchmark.yml` to `.github/workflows` to benchmark import times on `push` and `pull_request` to `main`.
>     - Uses `actions/checkout@v4`, `actions/setup-python@v4`, and `astral-sh/setup-uv@v3`.
>     - Runs `benchmark.py` with mock `OPENAI_API_KEY`.
>   - **Benchmark Script**:
>     - New `benchmark.py` to measure import times of modules like `kura.types`, `kura.k_means`, etc.
>     - Uses `subprocess` to time imports and `concurrent.futures` for parallel execution.
>   - **Lazy Imports**:
>     - Refactors `kura/__init__.py` to use lazy imports with `__getattr__` for modules like `SummaryModel`, `ClusterDescriptionModel`.
>     - Adds `_LAZY_IMPORTS` and `_OPTIONAL_IMPORTS` dictionaries for managing imports.
>   - **Type Checking**:
>     - Adds `TYPE_CHECKING` imports in `kura/base_classes/cluster.py`, `clustering_method.py`, `dimensionality.py`, `meta_cluster.py`, `summarisation.py`.
>     - Ensures imports are only for static analysis, not runtime.
>   - **Clustering Methods**:
>     - Updates `KmeansClusteringModel` and `HDBSCANClusteringMethod` to import `numpy` and `sklearn` only when needed.
>     - Adds lazy instantiation of default models in `generate_base_clusters_from_conversation_summaries()` in `kura/cluster.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=567-labs%2Fkura&utm_source=github&utm_medium=referral)<sup> for daa8fde9e6f25a70672ff6078e03784b5198946d. You can [customize](https://app.ellipsis.dev/567-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->