### PR TITLE
Flexible model client

### DIFF
--- a/kura/cluster.py
+++ b/kura/cluster.py
@@ -97,6 +97,8 @@ class ClusterDescriptionModel(BaseClusterDescriptionModel):
             checkpoint_filename: Filename for checkpointing
             console: Rich console for progress tracking
         """
+        import instructor
+
         # Handle both string model names and instructor client instances
         if isinstance(model, str):
             self.client = instructor.from_provider(model, async_client=True)

--- a/kura/cluster.py
+++ b/kura/cluster.py
@@ -14,6 +14,7 @@ from typing import Union, cast, Dict, List, Optional, TYPE_CHECKING
 if TYPE_CHECKING:
     from instructor.models import KnownModelName
     from instructor import AsyncInstructor
+    import instructor
 
 import numpy as np
 import asyncio
@@ -78,7 +79,9 @@ class ClusterDescriptionModel(BaseClusterDescriptionModel):
 
     def __init__(
         self,
-        model: Union[str, "KnownModelName"] = "openai/gpt-4o-mini",
+        model: Union[
+            str, "KnownModelName", "instructor.AsyncInstructor"
+        ] = "openai/gpt-4o-mini",
         max_concurrent_requests: int = 50,
         temperature: float = 0.2,
         checkpoint_filename: str = "clusters",
@@ -88,20 +91,25 @@ class ClusterDescriptionModel(BaseClusterDescriptionModel):
         Initialize ClusterModel with core configuration.
 
         Args:
-            model: model identifier (e.g., "openai/gpt-4o-mini")
+            model: model identifier (e.g., "openai/gpt-4o-mini") or instructor client
             max_concurrent_requests: Maximum concurrent API requests
             temperature: LLM temperature for generation
             checkpoint_filename: Filename for checkpointing
             console: Rich console for progress tracking
         """
-        self.model = model
+        # Handle both string model names and instructor client instances
+        if isinstance(model, str):
+            self.client = instructor.from_provider(model, async_client=True)
+        elif isinstance(model, instructor.AsyncInstructor):
+            self.client = model
+
         self.max_concurrent_requests = max_concurrent_requests
         self.temperature = temperature
         self._checkpoint_filename = checkpoint_filename
         self.console = console
 
         logger.info(
-            f"Initialized ClusterModel with model={model}, max_concurrent_requests={max_concurrent_requests}, temperature={temperature}"
+            f"Initialized ClusterModel with client={self.client}, max_concurrent_requests={max_concurrent_requests}, temperature={temperature}"
         )
 
     @property
@@ -116,10 +124,8 @@ class ClusterDescriptionModel(BaseClusterDescriptionModel):
         max_contrastive_examples: int = 10,
     ) -> List[Cluster]:
         """Generate clusters from a mapping of cluster IDs to summaries."""
-        import instructor
 
         self.sem = Semaphore(self.max_concurrent_requests)
-        self.client = instructor.from_provider(self.model, async_client=True)
 
         if not self.console:
             # Simple processing without rich display

--- a/kura/cluster.py
+++ b/kura/cluster.py
@@ -102,6 +102,10 @@ class ClusterDescriptionModel(BaseClusterDescriptionModel):
             self.client = instructor.from_provider(model, async_client=True)
         elif isinstance(model, instructor.AsyncInstructor):
             self.client = model
+        else:
+            raise ValueError(
+                f"Invalid model type of type({type(model)}). Expected str or instructor.AsyncInstructor."
+            )
 
         self.max_concurrent_requests = max_concurrent_requests
         self.temperature = temperature

--- a/kura/summarisation.py
+++ b/kura/summarisation.py
@@ -122,7 +122,7 @@ class SummaryModel(BaseSummaryModel):
         # Handle both string model names and instructor client instances
         if isinstance(model, str):
             self.client = instructor.from_provider(model, async_client=True)
-        if isinstance(model, instructor.AsyncInstructor):
+        elif isinstance(model, instructor.AsyncInstructor):
             self.client = model
         else:
             raise ValueError(


### PR DESCRIPTION
This makes it possible to either use a model string or just override and pass in an instructor client directly. This helps deal with cases where people might need to manually override the client
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Enhance model client flexibility by allowing `ClusterDescriptionModel`, `MetaClusterModel`, and `SummaryModel` to accept either a model string or an `instructor.AsyncInstructor` client.
> 
>   - **Behavior**:
>     - `ClusterDescriptionModel`, `MetaClusterModel`, and `SummaryModel` now accept either a model string or an `instructor.AsyncInstructor` client.
>     - Raises `ValueError` if the model type is neither a string nor an `AsyncInstructor`.
>   - **Initialization**:
>     - In `cluster.py`, `meta_cluster.py`, and `summarisation.py`, the `__init__` methods are updated to handle both string model names and instructor client instances.
>     - Imports `instructor` within the `__init__` methods to ensure availability when needed.
>   - **Logging**:
>     - Updates logging to reflect the use of `client` instead of `model` in initialization logs across the three files.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=567-labs%2Fkura&utm_source=github&utm_medium=referral)<sup> for 6b8584fb2f24755434dba8bc37bd6a76db7ac2c1. You can [customize](https://app.ellipsis.dev/567-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->