### PR TITLE
Add support for custom OpenAI base URLs

### DIFF
--- a/kura/cluster.py
+++ b/kura/cluster.py
@@ -83,6 +83,7 @@ class ClusterDescriptionModel(BaseClusterDescriptionModel):
         temperature: float = 0.2,
         checkpoint_filename: str = "clusters",
         console: Optional[Console] = None,
+        base_url: str | None = None,
     ):
         """
         Initialize ClusterModel with core configuration.
@@ -93,15 +94,17 @@ class ClusterDescriptionModel(BaseClusterDescriptionModel):
             temperature: LLM temperature for generation
             checkpoint_filename: Filename for checkpointing
             console: Rich console for progress tracking
+            base_url: Custom base URL for OpenAI-compatible endpoints (optional)
         """
         self.model = model
         self.max_concurrent_requests = max_concurrent_requests
         self.temperature = temperature
         self._checkpoint_filename = checkpoint_filename
         self.console = console
+        self.base_url = base_url
 
         logger.info(
-            f"Initialized ClusterModel with model={model}, max_concurrent_requests={max_concurrent_requests}, temperature={temperature}"
+            f"Initialized ClusterModel with model={model}, max_concurrent_requests={max_concurrent_requests}, temperature={temperature}, base_url={base_url}"
         )
 
     @property
@@ -119,7 +122,14 @@ class ClusterDescriptionModel(BaseClusterDescriptionModel):
         import instructor
 
         self.sem = Semaphore(self.max_concurrent_requests)
-        self.client = instructor.from_provider(self.model, async_client=True)
+
+        # Create client with custom base_url if provided for OpenAI models
+        if self.base_url and self.model.startswith("openai/"):
+            from openai import AsyncOpenAI
+            openai_client = AsyncOpenAI(base_url=self.base_url)
+            self.client = instructor.from_openai(openai_client)
+        else:
+            self.client = instructor.from_provider(self.model, async_client=True)
 
         if not self.console:
             # Simple processing without rich display

--- a/kura/embedding.py
+++ b/kura/embedding.py
@@ -42,8 +42,9 @@ class OpenAIEmbeddingModel(BaseEmbeddingModel):
         model_name: str = "text-embedding-3-small",
         model_batch_size: int = 50,
         n_concurrent_jobs: int = 5,
+        base_url: str | None = None,
     ):
-        self.client = AsyncOpenAI()
+        self.client = AsyncOpenAI(base_url=base_url)
         self.model_name = model_name
         self._model_batch_size = model_batch_size
         self._n_concurrent_jobs = n_concurrent_jobs

--- a/kura/summarisation.py
+++ b/kura/summarisation.py
@@ -159,6 +159,7 @@ class SummaryModel(BaseSummaryModel):
         checkpoint_filename: str = "summaries",
         console: Optional[Console] = None,
         cache: Optional[CacheStrategy] = None,
+        base_url: str | None = None,
     ):
         """
         Initialize SummaryModel with core configuration.
@@ -169,18 +170,20 @@ class SummaryModel(BaseSummaryModel):
             model: model identifier (e.g., "openai/gpt-4o-mini")
             max_concurrent_requests: Maximum concurrent API requests
             cache: Caching strategy to use (optional)
+            base_url: Custom base URL for OpenAI-compatible endpoints (optional)
         """
         self.model = model
         self.max_concurrent_requests = max_concurrent_requests
         self._checkpoint_filename = checkpoint_filename
         self.console = console
+        self.base_url = base_url
 
         # Initialize cache
         self.cache = cache
 
         cache_info = type(self.cache).__name__ if self.cache else "None"
         logger.info(
-            f"Initialized SummaryModel with model={model}, max_concurrent_requests={max_concurrent_requests}, cache={cache_info}"
+            f"Initialized SummaryModel with model={model}, max_concurrent_requests={max_concurrent_requests}, cache={cache_info}, base_url={base_url}"
         )
 
     @property
@@ -262,7 +265,13 @@ class SummaryModel(BaseSummaryModel):
 
         import instructor
 
-        client = instructor.from_provider(self.model, async_client=True)
+        # Create client with custom base_url if provided for OpenAI models
+        if self.base_url and self.model.startswith("openai/"):
+            from openai import AsyncOpenAI
+            openai_client = AsyncOpenAI(base_url=self.base_url)
+            client = instructor.from_openai(openai_client)
+        else:
+            client = instructor.from_provider(self.model, async_client=True)
 
         if not self.console:
             # Simple progress tracking with tqdm


### PR DESCRIPTION
This change adds a base_url parameter to all OpenAI-dependent models, allowing users to use OpenAI-compatible endpoints like Azure OpenAI, LocalAI, vLLM, or other custom deployments.

Changes:
- OpenAIEmbeddingModel: Add base_url parameter to __init__
- SummaryModel: Add base_url parameter and custom client creation logic
- ClusterDescriptionModel: Add base_url parameter and custom client creation logic
- MetaClusterModel: Add base_url parameter and custom client creation logic

The implementation checks if a base_url is provided and the model is an OpenAI model. If so, it creates an AsyncOpenAI client with the custom base_url and wraps it with instructor. Otherwise, it falls back to the default instructor.from_provider() behavior.

Generated with Claude Code
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `base_url` parameter to support custom OpenAI-compatible endpoints in several models, updating initialization and client creation logic accordingly.
> 
>   - **Behavior**:
>     - Adds `base_url` parameter to `OpenAIEmbeddingModel`, `SummaryModel`, `ClusterDescriptionModel`, and `MetaClusterModel` to support custom OpenAI-compatible endpoints.
>     - If `base_url` is provided and model is OpenAI, creates `AsyncOpenAI` client with `base_url`; otherwise, uses default `instructor.from_provider()`.
>   - **Models**:
>     - Updates `__init__` methods in `kura/embedding.py`, `kura/summarisation.py`, `kura/cluster.py`, and `kura/meta_cluster.py` to include `base_url` parameter.
>     - Modifies client creation logic in `generate_clusters()` in `kura/cluster.py`, `summarise()` in `kura/summarisation.py`, and `__init__()` in `kura/meta_cluster.py` to handle `base_url`.
>   - **Logging**:
>     - Updates logging in `__init__` methods to include `base_url` in initialization messages.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=567-labs%2Fkura&utm_source=github&utm_medium=referral)<sup> for db234f55f06ded9fd559e65424ca4f034165bfaa. You can [customize](https://app.ellipsis.dev/567-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->